### PR TITLE
Sort messages added to Github for check consistency

### DIFF
--- a/linty_fresh/reporters/github_reporter.py
+++ b/linty_fresh/reporters/github_reporter.py
@@ -60,12 +60,8 @@ class GithubReporter(object):
                 message_for_line = [':sparkles:Linty Fresh Says:sparkles::',
                                     '',
                                     '```']
-
-                reported_problems_for_line = set()
-                for problem in problems_for_line:
-                    if problem.message not in reported_problems_for_line:
-                        message_for_line.append(problem.message)
-                        reported_problems_for_line.add(problem.message)
+                message_for_line.extend(sorted(
+                    set(problem.message for problem in problems_for_line)))
                 message_for_line.append('```')
 
                 path = location[0]

--- a/tests/reporters/test_github_reporter.py
+++ b/tests/reporters/test_github_reporter.py
@@ -60,11 +60,18 @@ class GithubReporterTest(unittest.TestCase):
 
         reporter = github_reporter.create_reporter(mock_args)
         async_report = reporter.report([
+            # First comment to be added, with 2 messages
             Problem('some_dir/some_file', 40, 'this made me sad'),
-            Problem('some_dir/some_file', 40, 'really sad'),
+            Problem('some_dir/some_file', 40, 'yes, really sad'),
+            # Second comment to be added, with only 1 message
             Problem('another_file', 2, 'This is OK'),
             Problem('another_file', 2, 'This is OK'),
+            # This comment with 1 message already in the PR will not be added
             Problem('another_file', 3, 'I am a duplicate!'),
+            # This comment with 2 messages already in the PR will not be added
+            Problem('another_file', 4, 'I am also a duplicate!'),
+            Problem('another_file', 4, 'But on many lines!'),
+            # This comment on a file not in the PR will not be added
             Problem('missing_file', 42, "Don't report me!!!"),
         ])
 
@@ -112,7 +119,7 @@ class GithubReporterTest(unittest.TestCase):
 
                     ```
                     this made me sad
-                    really sad
+                    yes, really sad
                     ```'''),
                 'position': 3
             }, sort_keys=True)
@@ -174,6 +181,15 @@ class GithubReporterTest(unittest.TestCase):
 
                      ```
                      I am a duplicate!
+                     ```''')}, {
+                 'path': 'another_file',
+                 'position': 4,
+                 'body': textwrap.dedent('''\
+                     :sparkles:Linty Fresh Says:sparkles::
+
+                     ```
+                     But on many lines!
+                     I am also a duplicate!
                      ```''')}], sort_keys=True)),
             ('https://api.github.com/repos/foo/bar/pulls/1234/comments',
              'post'): FakeClientResponse('')


### PR DESCRIPTION
To know if a message should be added to Github we check if it was
already added.
Or if we have more than one messages for a line, they are not guaranteed
to be in the same order, so the check fail.

This commit simply sort the lines before adding them to the final
message to check.

(It also simplifies this part of the code using the fact that `set.add`
will not add a new occurence of the value if already present, so the
extra set and the `if..in` are not needed)