### PR TITLE
[pylint] Ensure path and line are present

### DIFF
--- a/linty_fresh/linters/pylint.py
+++ b/linty_fresh/linters/pylint.py
@@ -4,7 +4,7 @@ from linty_fresh.problem import Problem
 
 from typing import Set
 
-PYLINT_LINE_REGEX = re.compile(r'(?P<path>[^:]*):(?P<line>\d*):\s*'
+PYLINT_LINE_REGEX = re.compile(r'(?P<path>[^:]+):(?P<line>\d+):\s*'
                                r'(?:(?P<column>\d*):)?\s*'
                                r'(?P<message>.*)')
 

--- a/tests/linters/test_pylint.py
+++ b/tests/linters/test_pylint.py
@@ -12,6 +12,7 @@ class PyLintTest(unittest.TestCase):
         test_string = '''
 src/linters/pylint.py:10: [E302] expected 2 blank lines, found 1
 tests/linters/pylint.py:42: [E302] expected 2 blank lines, found 1
+::
 '''
         result = pylint.parse(test_string)
         self.assertEqual(2, len(result))


### PR DESCRIPTION
We need the path and the line to create the message, and the regex for
the pylint linter does not ensure it.

In a pylint report, it is possible to find a line containing only `::`
so the script crashes.

This commit fixes the problem by updating the `PYLINT_LINE_REGEX` to
force the presence of a path and a line.
