### PR TITLE
Add new linter for xcodebuild output

### DIFF
--- a/linty_fresh/linters/xcodebuild.py
+++ b/linty_fresh/linters/xcodebuild.py
@@ -1,0 +1,27 @@
+import os
+import re
+from typing import Set
+
+from linty_fresh.problem import Problem
+
+XCODEBUILD_LINE_REGEX = re.compile(r'(?P<path>[^:]*):'
+                                   r'((?P<line>\d*)|(?P<reference>[^:]*)):'
+                                   r'(?:(?P<column>\d*):)?\s*(?P<level>\w*):'
+                                   r'\s*(?P<message>.*)')
+
+
+def parse(contents: str, **kwargs) -> Set[Problem]:
+    result = set()  # type: Set[Problem]
+    for line in contents.splitlines():
+        match = XCODEBUILD_LINE_REGEX.match(line)
+        if match:
+            groups = match.groupdict()
+            line = groups['line'] or 0
+            message = groups['message']
+            reference = groups['reference']
+            if reference:
+                message = '{}: {}'.format(reference, message)
+
+            result.add(Problem(os.path.relpath(groups['path']),
+                               line, message))
+    return result

--- a/linty_fresh/main.py
+++ b/linty_fresh/main.py
@@ -8,6 +8,7 @@ from linty_fresh.linters import passthrough
 from linty_fresh.linters import pmd
 from linty_fresh.linters import pylint
 from linty_fresh.linters import swiftlint
+from linty_fresh.linters import xcodebuild
 from linty_fresh.reporters import github_reporter
 
 from typing import Any, Dict  # noqa
@@ -26,6 +27,7 @@ LINTERS = {
     'pmd': pmd,
     'pylint': pylint,
     'swiftlint': swiftlint,
+    'xcodebuild': xcodebuild,
 }  # type: Dict[str, Any]
 
 

--- a/tests/linters/test_xcodebuild.py
+++ b/tests/linters/test_xcodebuild.py
@@ -1,0 +1,56 @@
+import unittest
+import os
+from linty_fresh.linters import xcodebuild
+from linty_fresh.problem import Problem
+
+
+class XcodebuildTest(unittest.TestCase):
+    def test_empty_parse(self):
+        self.assertEqual(set(), xcodebuild.parse(''))
+
+    def test_parse_errors(self):
+        test_string = [
+            "<unknown>:0: error: no such file or directory: 'foo.swift'",
+            "{}/Classes/foo/bar baz/qux.swift:201:21: "
+            "error: use of unresolved identifier 'FooBar'"
+            .format(os.path.curdir),
+            "{}/Classes/foo/bar/Protocols/SomeProtocol.swift:7:10: "
+            "note: did you mean 'SomeOtherProtocol'?"
+            .format(os.path.curdir),
+            "{}/Resources/Storyboards & XIBs/Foo.storyboard:kB7-Bl-wC0: "
+            "warning: Unsupported configuration of constraint attributes. "
+            "This may produce unexpected results at runtime before Xcode 5.1"
+            .format(os.path.curdir),
+        ]
+
+        result = xcodebuild.parse('\n'.join(test_string))
+        self.assertEqual(4, len(result))
+
+        self.assertIn(
+            Problem('<unknown>',
+                    0,
+                    "no such file or directory: 'foo.swift'"),
+            result)
+
+        self.assertIn(
+            Problem('Classes/foo/bar baz/'
+                    'qux.swift',
+                    201,
+                    "use of unresolved identifier 'FooBar'"),
+            result)
+
+        self.assertIn(
+            Problem('Classes/foo/bar/Protocols/'
+                    'SomeProtocol.swift',
+                    7,
+                    "did you mean 'SomeOtherProtocol'?"),
+            result)
+
+        self.assertIn(
+            Problem('Resources/Storyboards & XIBs/'
+                    'Foo.storyboard',
+                    0,
+                    'kB7-Bl-wC0: Unsupported configuration of '
+                    'constraint attributes. This may produce unexpected '
+                    'results at runtime before Xcode 5.1'),
+            result)


### PR DESCRIPTION
This linter lets us capture xcodebuild / ibtool output and surface the
notes/warnings/errors on PRs.