### PR TITLE
Fix test case class names

### DIFF
--- a/tests/linters/test_checkstyle.py
+++ b/tests/linters/test_checkstyle.py
@@ -4,7 +4,7 @@ from linty_fresh.linters import checkstyle
 from linty_fresh.problem import Problem
 
 
-class PyLintTest(unittest.TestCase):
+class CheckstyleTest(unittest.TestCase):
     def test_empty_parse(self):
         self.assertEqual(set(), checkstyle.parse(''))
 

--- a/tests/linters/test_mypy.py
+++ b/tests/linters/test_mypy.py
@@ -4,7 +4,7 @@ from linty_fresh.linters import mypy
 from linty_fresh.problem import Problem
 
 
-class PyLintTest(unittest.TestCase):
+class MypyTest(unittest.TestCase):
     def test_empty_parse(self):
         self.assertEqual(set(), mypy.parse(''))
 

--- a/tests/linters/test_swiftlint.py
+++ b/tests/linters/test_swiftlint.py
@@ -4,7 +4,7 @@ from linty_fresh.linters import swiftlint
 from linty_fresh.problem import Problem
 
 
-class PyLintTest(unittest.TestCase):
+class SwiftlintTest(unittest.TestCase):
     def test_empty_parse(self):
         self.assertEqual(set(), swiftlint.parse(''))
 


### PR DESCRIPTION
It looks like we copied these tests from the pylint tests and forgot to
change the class names.