### PR TITLE
Add passthrough linter

### DIFF
--- a/linty_fresh/linters/passthrough.py
+++ b/linty_fresh/linters/passthrough.py
@@ -1,0 +1,7 @@
+from typing import Set
+
+from linty_fresh.problem import Problem
+
+
+def parse(contents: str, **kwargs) -> Set[Problem]:
+    return set(Problem('', 0, x) for x in contents.splitlines())

--- a/linty_fresh/main.py
+++ b/linty_fresh/main.py
@@ -4,6 +4,7 @@ import asyncio
 from linty_fresh.linters import android
 from linty_fresh.linters import checkstyle
 from linty_fresh.linters import mypy
+from linty_fresh.linters import passthrough
 from linty_fresh.linters import pmd
 from linty_fresh.linters import pylint
 from linty_fresh.linters import swiftlint
@@ -21,9 +22,10 @@ LINTERS = {
     'android': android,
     'checkstyle': checkstyle,
     'mypy': mypy,
+    'passthrough': passthrough,
+    'pmd': pmd,
     'pylint': pylint,
     'swiftlint': swiftlint,
-    'pmd': pmd,
 }  # type: Dict[str, Any]
 
 

--- a/tests/linters/test_passthrough.py
+++ b/tests/linters/test_passthrough.py
@@ -1,0 +1,20 @@
+import unittest
+from linty_fresh.linters import passthrough
+from linty_fresh.problem import Problem
+
+
+class PassthroughTest(unittest.TestCase):
+    def test_empty_parse(self):
+        self.assertEqual(set(), passthrough.parse(''))
+
+    def test_parse_errors(self):
+        test_string = [
+            'Something happened!',
+            "More stuff 'happened'",
+        ]
+
+        result = passthrough.parse('\n'.join(test_string))
+        self.assertEqual(2, len(result))
+
+        self.assertIn(Problem('', 0, 'Something happened!'), result)
+        self.assertIn(Problem('', 0, "More stuff 'happened'"), result)


### PR DESCRIPTION
This linter just passes all text through to the reporter. This can be
used for unstructured text where you don't have file path / line
information, and all the text is valuable.