### PR TITLE
Changes github comment to include linter name

### DIFF
--- a/linty_fresh/main.py
+++ b/linty_fresh/main.py
@@ -72,7 +72,7 @@ async def run_loop(args):
         existing_problems = await storage_engine.get_existing_problems()
         problems = problems.difference(existing_problems)
 
-    awaitable_array.extend([reporter.report(problems) for
+    awaitable_array.extend([reporter.report(linter, problems) for
                             reporter in
                             reporters])
     await asyncio.gather(*awaitable_array)

--- a/linty_fresh/main.py
+++ b/linty_fresh/main.py
@@ -31,6 +31,8 @@ def create_parser() -> argparse.ArgumentParser:
                         help='The reporter to use when reporting errors.')
     parser.add_argument('--linter', type=str, required=True,
                         help='The type of lint file to parse.')
+    parser.add_argument('--linter_name', type=str, default=None,
+                        help='Override linter name for PR reporting')
     parser.add_argument('--store_problems', default=False, action='store_true',
                         help='Whether or not to store lint errors as git '
                              'notes and filter out problems')
@@ -38,6 +40,7 @@ def create_parser() -> argparse.ArgumentParser:
                         help='The lint file being parsed.')
     parser.add_argument('--pass-warnings', default=False, action='store_true',
                         help='(ANDROID ONLY) Pass Android linter on warnings.')
+
     for name, reporter in REPORTERS.items():
         reporter.register_arguments(parser)
     return parser
@@ -72,7 +75,8 @@ async def run_loop(args):
         existing_problems = await storage_engine.get_existing_problems()
         problems = problems.difference(existing_problems)
 
-    awaitable_array.extend([reporter.report(linter, problems) for
+    linter_name = args.linter_name or linter
+    awaitable_array.extend([reporter.report(linter_name, problems) for
                             reporter in
                             reporters])
     await asyncio.gather(*awaitable_array)

--- a/linty_fresh/reporters/github_reporter.py
+++ b/linty_fresh/reporters/github_reporter.py
@@ -31,6 +31,7 @@ GenericProblem = TypeVar('GenericProblem', Problem, TestProblem)
 
 
 class GithubReporter(object):
+
     def __init__(self,
                  auth_token: str,
                  organization: str,
@@ -43,7 +44,8 @@ class GithubReporter(object):
         self.pr = pr_number
         self.commit = commit
 
-    async def report(self, problems: List[GenericProblem]) -> None:
+    async def report(self, reporter: str,
+                     problems: List[GenericProblem]) -> None:
         if isinstance(list(problems)[0], TestProblem):
             grouped_problems = TestProblem.group_by_group(problems)
         else:
@@ -61,8 +63,10 @@ class GithubReporter(object):
             pr_url = self._get_pr_url()
             no_matching_line_number = []
             for location, problems_for_line in grouped_problems:
-                message_for_line = [':sparkles:Linty Fresh Says:sparkles::',
-                                    '']
+                message_for_line = [
+                    ':sparkles:{0} says:sparkles::'.format(reporter),
+                    ''
+                ]
 
                 reported_problems_for_line = set()
 
@@ -99,11 +103,11 @@ class GithubReporter(object):
                     no_matching_line_number.append((location,
                                                     problems_for_line))
             if lint_errors > MAX_LINT_ERROR_REPORTS:
-                message = ''':sparkles:Linty Fresh Says:sparkles::
+                message = ''':sparkles:{0} says:sparkles::
 
-Too many lint errors to report inline!  {0} lines have a problem.
-Only reporting the first {1}.'''.format(
-                    lint_errors, MAX_LINT_ERROR_REPORTS)
+Too many lint errors to report inline!  {1} lines have a problem.
+Only reporting the first {2}.'''.format(
+                    reporter, lint_errors, MAX_LINT_ERROR_REPORTS)
                 data = json.dumps({
                     'body': message
                 })
@@ -121,8 +125,9 @@ Only reporting the first {1}.'''.format(
                     for problem in problems_for_line:
                         no_matching_line_messages.append('\t{0}'.format(
                             problem.message))
-                message = ('Linters found some problems with lines not '
-                           'modified by this commit:\n```\n{0}\n```'.format(
+                message = ('{0} found some problems with lines not '
+                           'modified by this commit:\n```\n{1}\n```'.format(
+                               reporter,
                                '\n'.join(no_matching_line_messages)))
                 data = json.dumps({
                     'body': message

--- a/linty_fresh/reporters/github_reporter.py
+++ b/linty_fresh/reporters/github_reporter.py
@@ -44,7 +44,7 @@ class GithubReporter(object):
         self.pr = pr_number
         self.commit = commit
 
-    async def report(self, reporter: str,
+    async def report(self, linter_name: str,
                      problems: List[GenericProblem]) -> None:
         if isinstance(list(problems)[0], TestProblem):
             grouped_problems = TestProblem.group_by_group(problems)
@@ -63,10 +63,7 @@ class GithubReporter(object):
             pr_url = self._get_pr_url()
             no_matching_line_number = []
             for location, problems_for_line in grouped_problems:
-                message_for_line = [
-                    ':sparkles:{0} says:sparkles::'.format(reporter),
-                    ''
-                ]
+                message_for_line = ['{0} says:'.format(linter_name), '']
 
                 reported_problems_for_line = set()
 
@@ -103,11 +100,11 @@ class GithubReporter(object):
                     no_matching_line_number.append((location,
                                                     problems_for_line))
             if lint_errors > MAX_LINT_ERROR_REPORTS:
-                message = ''':sparkles:{0} says:sparkles::
+                message = '''{0} says:
 
 Too many lint errors to report inline!  {1} lines have a problem.
 Only reporting the first {2}.'''.format(
-                    reporter, lint_errors, MAX_LINT_ERROR_REPORTS)
+                    linter_name, lint_errors, MAX_LINT_ERROR_REPORTS)
                 data = json.dumps({
                     'body': message
                 })
@@ -127,7 +124,7 @@ Only reporting the first {2}.'''.format(
                             problem.message))
                 message = ('{0} found some problems with lines not '
                            'modified by this commit:\n```\n{1}\n```'.format(
-                               reporter,
+                               linter_name,
                                '\n'.join(no_matching_line_messages)))
                 data = json.dumps({
                     'body': message

--- a/tests/reporters/test_github_reporter.py
+++ b/tests/reporters/test_github_reporter.py
@@ -59,7 +59,7 @@ class GithubReporterTest(unittest.TestCase):
             mock_client_session)
 
         reporter = github_reporter.create_reporter(mock_args)
-        async_report = reporter.report([
+        async_report = reporter.report('unit-test-linter', [
             Problem('some_dir/some_file', 40, 'this made me sad'),
             Problem('some_dir/some_file', 40, 'really sad'),
             Problem('another_file', 2, 'This is OK'),
@@ -92,7 +92,7 @@ class GithubReporterTest(unittest.TestCase):
                 'commit_id': 'abc123',
                 'path': 'another_file',
                 'body': textwrap.dedent('''\
-                    :sparkles:Linty Fresh Says:sparkles::
+                    :sparkles:unit-test-linter says:sparkles::
 
                     ```
                     This is OK
@@ -109,7 +109,7 @@ class GithubReporterTest(unittest.TestCase):
                 'commit_id': 'abc123',
                 'path': 'some_dir/some_file',
                 'body': textwrap.dedent('''\
-                    :sparkles:Linty Fresh Says:sparkles::
+                    :sparkles:unit-test-linter says:sparkles::
 
                     ```
                     this made me sad
@@ -127,7 +127,7 @@ class GithubReporterTest(unittest.TestCase):
                 'commit_id': 'abc123',
                 'path': 'another_file',
                 'body': textwrap.dedent('''\
-                    :sparkles:Linty Fresh Says:sparkles::
+                    :sparkles:unit-test-linter says:sparkles::
 
                     (From line 52)
                     ```
@@ -143,7 +143,11 @@ class GithubReporterTest(unittest.TestCase):
             },
             data=json.dumps({
                 'body': textwrap.dedent('''\
-                '''),
+                    unit-test-linter found some problems with lines not modified by this commit:
+                    ```
+                    missing_file:42:
+                    \tMissing file comment!!!
+                    ```'''),
             }, sort_keys=True)
         )
 
@@ -153,6 +157,7 @@ class GithubReporterTest(unittest.TestCase):
         self.assertIn(first_comment, fake_client_session.calls)
         self.assertIn(second_comment, fake_client_session.calls)
         self.assertIn(close_enough_comment, fake_client_session.calls)
+        self.assertIn(missing_file_call, fake_client_session.calls)
 
     @patch('linty_fresh.reporters.github_reporter.aiohttp.ClientSession')
     @patch('os.getenv')
@@ -167,13 +172,13 @@ class GithubReporterTest(unittest.TestCase):
 
         problems = [Problem('another_file', x, 'Wat') for x in range(1, 13)]
 
-        async_report = reporter.report(problems)
+        async_report = reporter.report('unit-test-linter', problems)
 
         loop = asyncio.get_event_loop()
         loop.run_until_complete(async_report)
 
         overflow_message = textwrap.dedent('''\
-            :sparkles:Linty Fresh Says:sparkles::
+            :sparkles:unit-test-linter says:sparkles::
 
             Too many lint errors to report inline!  12 lines have a problem.
             Only reporting the first 10.''')
@@ -200,7 +205,7 @@ class GithubReporterTest(unittest.TestCase):
                  'path': 'another_file',
                  'position': 3,
                  'body': textwrap.dedent('''\
-                     :sparkles:Linty Fresh Says:sparkles::
+                     :sparkles:unit-test-linter says:sparkles::
 
                      ```
                      I am a duplicate!

--- a/tests/reporters/test_github_reporter.py
+++ b/tests/reporters/test_github_reporter.py
@@ -92,7 +92,7 @@ class GithubReporterTest(unittest.TestCase):
                 'commit_id': 'abc123',
                 'path': 'another_file',
                 'body': textwrap.dedent('''\
-                    :sparkles:unit-test-linter says:sparkles::
+                    unit-test-linter says:
 
                     ```
                     This is OK
@@ -109,7 +109,7 @@ class GithubReporterTest(unittest.TestCase):
                 'commit_id': 'abc123',
                 'path': 'some_dir/some_file',
                 'body': textwrap.dedent('''\
-                    :sparkles:unit-test-linter says:sparkles::
+                    unit-test-linter says:
 
                     ```
                     this made me sad
@@ -127,7 +127,7 @@ class GithubReporterTest(unittest.TestCase):
                 'commit_id': 'abc123',
                 'path': 'another_file',
                 'body': textwrap.dedent('''\
-                    :sparkles:unit-test-linter says:sparkles::
+                    unit-test-linter says:
 
                     (From line 52)
                     ```
@@ -178,7 +178,7 @@ class GithubReporterTest(unittest.TestCase):
         loop.run_until_complete(async_report)
 
         overflow_message = textwrap.dedent('''\
-            :sparkles:unit-test-linter says:sparkles::
+            unit-test-linter says:
 
             Too many lint errors to report inline!  12 lines have a problem.
             Only reporting the first 10.''')
@@ -205,7 +205,7 @@ class GithubReporterTest(unittest.TestCase):
                  'path': 'another_file',
                  'position': 3,
                  'body': textwrap.dedent('''\
-                     :sparkles:unit-test-linter says:sparkles::
+                     unit-test-linter says:
 
                      ```
                      I am a duplicate!


### PR DESCRIPTION
Our use case is that we are running many commands through linty fresh - for our iOS repo, we have xcodebuild, swiftlint, and stringslint errors.

When one of these fails, people have ended up being confused about the difference between a "lint" step - "oh, stupid lint" ... except that the code is not compiling ("xcodebuild").

I've updated the comments to be more specific.  For example rather than saying "Linty Fresh Says" now we'll say "xcodebuild says".

By default the name of the --linter will be used. I also added a --linter_name argument which can be used to override this in cases where it might not make sense (e.g. passthrough)