### PR TITLE
Update passthrough linter to not split lines

### DIFF
--- a/linty_fresh/linters/passthrough.py
+++ b/linty_fresh/linters/passthrough.py
@@ -4,4 +4,7 @@ from linty_fresh.problem import Problem
 
 
 def parse(contents: str, **kwargs) -> Set[Problem]:
-    return set(Problem('', 0, x) for x in contents.splitlines())
+    if contents:
+        return set([Problem('', 0, contents)])
+    else:
+        return set()

--- a/tests/linters/test_passthrough.py
+++ b/tests/linters/test_passthrough.py
@@ -14,7 +14,8 @@ class PassthroughTest(unittest.TestCase):
         ]
 
         result = passthrough.parse('\n'.join(test_string))
-        self.assertEqual(2, len(result))
+        self.assertEqual(1, len(result))
 
-        self.assertIn(Problem('', 0, 'Something happened!'), result)
-        self.assertIn(Problem('', 0, "More stuff 'happened'"), result)
+        self.assertIn(Problem('', 0,
+                              'Something happened!\n'
+                              "More stuff 'happened'"), result)


### PR DESCRIPTION
This caused issues if the linter expected the lines being passed through
to be in a specific order.