### PR TITLE
README fix for secret link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ for OSS projects).  Then add that token as a secret to your CI system as the
 environment variable `GITHUB_AUTH_TOKEN`.  You should ensure this user and it's
 token are scoped down as much as possible.  You should assume that anyone who
 has permissions to run a job in your CI system would have access to this token.
-See Travis CI documentation [storing encrypted secrets]
-(https://docs.travis-ci.com/user/encryption-keys/) for more information.
+See Travis CI documentation [storing encrypted secrets][] for more information.
 
 If you are looking for a good secret management system to store secrets like
 this, check out [Confidant](https://github.com/lyft/confidant/).
@@ -73,3 +72,5 @@ Supported Linters
 - [Mypy](http://mypy-lang.org/)
 - [Checkstyle](http://checkstyle.sourceforge.net/)
 - [Android](https://developer.android.com/studio/write/lint.html)
+
+[storing encrypted secrets]: https://docs.travis-ci.com/user/encryption-keys/


### PR DESCRIPTION
I figure some automated tooling to make it fit ~80 chars broke your link, so I used the footnote mode to make it fit.

![screen shot 2017-05-15 at 21 26 33](https://cloud.githubusercontent.com/assets/49038/26077811/49f9bd90-39b5-11e7-9c6f-1b09f03b7f00.png)