### PR TITLE
Add option to delete stale GitHub comments as they're fixed

### DIFF
--- a/linty_fresh/main.py
+++ b/linty_fresh/main.py
@@ -40,6 +40,9 @@ def create_parser() -> argparse.ArgumentParser:
                         help='The lint file being parsed.')
     parser.add_argument('--pass-warnings', default=False, action='store_true',
                         help='(ANDROID ONLY) Pass Android linter on warnings.')
+    parser.add_argument('--delete_previous_comments', default=False,
+                        action='store_true',
+                        help='Delete stale linter comments.')
 
     for name, reporter in REPORTERS.items():
         reporter.register_arguments(parser)

--- a/tests/utils/fake_client_session.py
+++ b/tests/utils/fake_client_session.py
@@ -66,6 +66,11 @@ class FakeClientSession(object):
         self.calls.append(call.post(url, *args, **updated_kwargs))
         return _RequestContextManager(self._get_stored_value(url, 'post'))
 
+    def delete(self, url, *args, **kwargs):
+        updated_kwargs = self._update_headers(kwargs)
+        self.calls.append(call.delete(url, *args, **updated_kwargs))
+        return _RequestContextManager(self._get_stored_value(url, 'delete'))
+
     def _update_headers(self, kwargs):
         result = copy.copy(kwargs)
         merged_headers = copy.copy(self.headers) if self.headers else {}


### PR DESCRIPTION
This adds a new flag `--delete_previous_comments` to delete previous linty_fresh comments as they are fixed on a PR. 

The general approach used by this is:

1. Fetch all PR comments and load them into a set, if you find
duplicates from the new comments, remove those from the set. Whatever is
left, delete
2. Fetch all top level issue comments (this is a separate endpoint),
delete all of them, and remake those.

Comments that should be loaded are picked by them matching the linter name passed (or the default one if you didn't pass a custom `--linter_name`). This allows you to have multiple CI jobs reporting with linty_fresh, and only delete their own errors. But if you don't de-duplicate these, you will lose errors.

This fixes https://github.com/lyft/linty_fresh/issues/24