### PR TITLE
Fix GitHub url in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     """,
     author='Roy Williams',
     author_email='rwilliams@lyft.com',
-    url='https://github.com/lyft/linty-fresh',
+    url='https://github.com/lyft/linty_fresh',
     packages=find_packages(exclude=['tests*']),
     include_package_data=True,
     setup_requires=[


### PR DESCRIPTION
I noticed that the `Homepage` link on PyPI was not correct, see:
    https://pypi.org/project/linty-fresh/