### PR TITLE
Fix reading long lines

### DIFF
--- a/linty_fresh/reporters/github_reporter.py
+++ b/linty_fresh/reporters/github_reporter.py
@@ -204,7 +204,7 @@ Only reporting the first {2}.""".format(
                    repo=self.repo,
                    pr=self.pr))
         async with client_session.get(url, headers=headers) as response:
-            async for line in response.content:
+            for line in response.content.readline():
                 line = line.decode()
                 file_match = FILE_START_REGEX.match(line)
                 if file_match:

--- a/tests/utils/fake_client_session.py
+++ b/tests/utils/fake_client_session.py
@@ -98,3 +98,6 @@ class FakeStreamReader(object):
             return self.lines[self.line_index - 1].encode()
         else:
             raise StopAsyncIteration
+
+    def readline(self):
+        return map(str.encode, self.lines)


### PR DESCRIPTION
For single lines that are very very long (tested > 61k for a single
line), reading line by line would fail. Calling `readline` directly
fixes this by not limiting the length of the content, which is fine for
our use case.