### PR TITLE
Update xcodebuild regex to exclude some logs

### DIFF
--- a/linty_fresh/linters/xcodebuild.py
+++ b/linty_fresh/linters/xcodebuild.py
@@ -7,8 +7,9 @@ from linty_fresh.problem import Problem
 XCODEBUILD_LINE_REGEX = re.compile(
     r'(?P<path>[^:]*):'
     r'((?P<line>\d*)|(?P<reference>[^:]*)):'
-    r'(?:(?P<column>\d*):)?\s*(?P<level>((?i)error|warn(ing)?|note|info)):'
-    r'\s*(?P<message>.*)'
+    r'(?:(?P<column>\d*):)?\s*(?P<level>(error|warn(ing)?|note|info)):'
+    r'\s*(?P<message>.*)',
+    re.IGNORECASE,
 )
 
 

--- a/linty_fresh/linters/xcodebuild.py
+++ b/linty_fresh/linters/xcodebuild.py
@@ -7,7 +7,7 @@ from linty_fresh.problem import Problem
 XCODEBUILD_LINE_REGEX = re.compile(
     r'(?P<path>[^:]*):'
     r'((?P<line>\d*)|(?P<reference>[^:]*)):'
-    r'(?:(?P<column>\d*):)?\s*(?P<level>(error|warning|note)):'
+    r'(?:(?P<column>\d*):)?\s*(?P<level>((?i)error|warn(ing)?|note|info)):'
     r'\s*(?P<message>.*)'
 )
 

--- a/linty_fresh/linters/xcodebuild.py
+++ b/linty_fresh/linters/xcodebuild.py
@@ -4,10 +4,12 @@ from typing import Set
 
 from linty_fresh.problem import Problem
 
-XCODEBUILD_LINE_REGEX = re.compile(r'(?P<path>[^:]*):'
-                                   r'((?P<line>\d*)|(?P<reference>[^:]*)):'
-                                   r'(?:(?P<column>\d*):)?\s*(?P<level>\w*):'
-                                   r'\s*(?P<message>.*)')
+XCODEBUILD_LINE_REGEX = re.compile(
+    r'(?P<path>[^:]*):'
+    r'((?P<line>\d*)|(?P<reference>[^:]*)):'
+    r'(?:(?P<column>\d*):)?\s*(?P<level>(error|warning|note)):'
+    r'\s*(?P<message>.*)'
+)
 
 
 def parse(contents: str, **kwargs) -> Set[Problem]:

--- a/tests/linters/test_xcodebuild.py
+++ b/tests/linters/test_xcodebuild.py
@@ -54,3 +54,13 @@ class XcodebuildTest(unittest.TestCase):
                     'constraint attributes. This may produce unexpected '
                     'results at runtime before Xcode 5.1'),
             result)
+
+    def test_should_not_parse(self):
+        test_string = [
+            "Details:  log recorder was sent "
+            "-stopRecordingWithInfo:completionBlock: after it had already "
+            "been asked to stop recording.",
+        ]
+
+        result = xcodebuild.parse('\n'.join(test_string))
+        self.assertEqual(0, len(result))

--- a/tests/linters/test_xcodebuild.py
+++ b/tests/linters/test_xcodebuild.py
@@ -11,6 +11,7 @@ class XcodebuildTest(unittest.TestCase):
     def test_parse_errors(self):
         test_string = [
             "<unknown>:0: error: no such file or directory: 'foo.swift'",
+            "<unknown>:0: ERROR: no such file or directory: 'case.swift'",
             "{}/Classes/foo/bar baz/qux.swift:201:21: "
             "error: use of unresolved identifier 'FooBar'"
             .format(os.path.curdir),
@@ -24,12 +25,18 @@ class XcodebuildTest(unittest.TestCase):
         ]
 
         result = xcodebuild.parse('\n'.join(test_string))
-        self.assertEqual(4, len(result))
+        self.assertEqual(5, len(result))
 
         self.assertIn(
             Problem('<unknown>',
                     0,
                     "no such file or directory: 'foo.swift'"),
+            result)
+
+        self.assertIn(
+            Problem('<unknown>',
+                    0,
+                    "no such file or directory: 'case.swift'"),
             result)
 
         self.assertIn(


### PR DESCRIPTION
In Xcode 10 there are some new logs that matched the looser version of
this regex, even though they weren't errors. Instead we now limit the
valid level matches.