### PR TITLE
Only install typing module before Python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     install_requires=[
         'aiohttp>=0.19.0, <3.0.0',
-        'typing>=3.5.0.1, <4.0.0',
+        'typing>=3.5.0.1, <4.0.0;python_version<"3.7"',
     ],
     classifiers=[
         'Environment :: Console',


### PR DESCRIPTION
FYI: I ran into this while running linty-fresh tests in Python 3.7

As per the package on PyPi, one does not need to install this after
Python 3.5: https://pypi.org/project/typing/

I chose to use < 3.7 here since typing between 3.6/3.7 differs as well,
and it could be that the typing module on PyPi backports some of that.