### PR TITLE
Fix commenting on specific lines

### DIFF
--- a/linty_fresh/reporters/github_reporter.py
+++ b/linty_fresh/reporters/github_reporter.py
@@ -206,7 +206,7 @@ Only reporting the first {2}.""".format(
         async with client_session.get(url, headers=headers) as response:
             # Collect the entire response before reading it. If you iterate
             # over lines instead, very long lines cause exceptions
-            content = b""
+            content = b''
             async for chunk in response.content.iter_any():
                 content += chunk
 

--- a/linty_fresh/reporters/github_reporter.py
+++ b/linty_fresh/reporters/github_reporter.py
@@ -204,7 +204,13 @@ Only reporting the first {2}.""".format(
                    repo=self.repo,
                    pr=self.pr))
         async with client_session.get(url, headers=headers) as response:
-            for line in response.content.readline():
+            # Collect the entire response before reading it. If you iterate
+            # over lines instead, very long lines cause exceptions
+            content = b""
+            async for chunk in response.content.iter_any():
+                content += chunk
+
+            for line in content.splitlines():
                 line = line.decode()
                 file_match = FILE_START_REGEX.match(line)
                 if file_match:

--- a/tests/utils/fake_client_session.py
+++ b/tests/utils/fake_client_session.py
@@ -88,16 +88,16 @@ class FakeStreamReader(object):
         self.lines = content.splitlines()
         self.line_index = 0
 
-    async def __aiter__(self):
+    def __aiter__(self):
         self.line_index = 0
         return self
 
     async def __anext__(self):
         if self.line_index < len(self.lines):
             self.line_index += 1
-            return self.lines[self.line_index - 1].encode()
+            return (self.lines[self.line_index - 1] + "\n").encode()
         else:
             raise StopAsyncIteration
 
-    def readline(self):
-        return map(str.encode, self.lines)
+    def iter_any(self):
+        return self


### PR DESCRIPTION
55c7985aca20a0d13834760c5af34f799326fd14 broke commenting on specific
lines. This still handles very very long lines