### PR TITLE
Update xcodebuild linter to not capture 'note' level logs

### DIFF
--- a/linty_fresh/linters/xcodebuild.py
+++ b/linty_fresh/linters/xcodebuild.py
@@ -7,12 +7,10 @@ from linty_fresh.problem import Problem
 XCODEBUILD_LINE_REGEX = re.compile(
     r'(?P<path>[^:]*):'
     r'((?P<line>\d*)|(?P<reference>[^:]*)):'
-    r'(?:(?P<column>\d*):)?\s*(?P<level>(error|warn(ing)?|note|info)):'
+    r'(?:(?P<column>\d*):)?\s*(?P<level>(error|warn(ing)?|info)):'
     r'\s*(?P<message>.*)',
     re.IGNORECASE,
 )
-
-CLASS_NAME = re.compile(r'[A-Z]\w+\.[A-Z]\w+$')
 
 
 def parse(contents: str, **kwargs) -> Set[Problem]:
@@ -21,17 +19,12 @@ def parse(contents: str, **kwargs) -> Set[Problem]:
         match = XCODEBUILD_LINE_REGEX.match(line)
         if match:
             groups = match.groupdict()
-            path = groups['path']
             line = groups['line'] or 0
-            level = groups['level']
             message = groups['message']
             reference = groups['reference']
             if reference:
                 message = '{}: {}'.format(reference, message)
 
-            if CLASS_NAME.match(path) and level == 'note':
-                # Ignore non-file references (ex UIKit.UIScrollViewDelegate)
-                continue
-
-            result.add(Problem(os.path.relpath(path), line, message))
+            result.add(Problem(os.path.relpath(groups['path']),
+                               line, message))
     return result

--- a/tests/linters/test_xcodebuild.py
+++ b/tests/linters/test_xcodebuild.py
@@ -22,6 +22,8 @@ class XcodebuildTest(unittest.TestCase):
             "warning: Unsupported configuration of constraint attributes. "
             "This may produce unexpected results at runtime before Xcode 5.1"
             .format(os.path.curdir),
+            "UIKit.UIScrollViewDelegate:23:41: "
+            "note: requirement 'viewForZooming(in:)' declared here"
         ]
 
         result = xcodebuild.parse('\n'.join(test_string))

--- a/tests/linters/test_xcodebuild.py
+++ b/tests/linters/test_xcodebuild.py
@@ -27,7 +27,7 @@ class XcodebuildTest(unittest.TestCase):
         ]
 
         result = xcodebuild.parse('\n'.join(test_string))
-        self.assertEqual(5, len(result))
+        self.assertEqual(4, len(result))
 
         self.assertIn(
             Problem('<unknown>',
@@ -46,13 +46,6 @@ class XcodebuildTest(unittest.TestCase):
                     'qux.swift',
                     201,
                     "use of unresolved identifier 'FooBar'"),
-            result)
-
-        self.assertIn(
-            Problem('Classes/foo/bar/Protocols/'
-                    'SomeProtocol.swift',
-                    7,
-                    "did you mean 'SomeOtherProtocol'?"),
             result)
 
         self.assertIn(


### PR DESCRIPTION
`clang` and `swiftc` diagnostics usually include 'notes' about errors and warnings. These notes can be helpful, but also can be excessive/verbose/noisy. Notes can also reference class names instead of paths. For example:

```
UIKit.UIScrollViewDelegate:19:26: note: requirement 'viewForZooming(in:)' declared here
```

In this case, linty_fresh adds a comment on the PR with the comment:

> I found some problems with lines not modified by this commit

This isn't desired behavior.

This changes the `xcodebuild` parser to ignore `note` diagnostics.