### PR TITLE
Set per_page param for getting github comments to max

### DIFF
--- a/linty_fresh/reporters/github_reporter.py
+++ b/linty_fresh/reporters/github_reporter.py
@@ -5,6 +5,7 @@ import os
 import re
 from collections import defaultdict
 from typing import Any, Dict, List, MutableMapping, Optional, Set, TypeVar
+from urllib.parse import parse_qs, urlencode, urlparse
 
 import aiohttp
 
@@ -295,6 +296,14 @@ Only reporting the first {2}.""".format(
     async def _fetch_message_json_from_url(
             client_session, url, linter_name
     ) -> [Any]:
+        def update_url(orig_url: str, additional_query: Dict[str, Any]) -> str:
+            parsed_url = urlparse(orig_url)
+            original_params = parse_qs(parsed_url.query)
+            updated_query = urlencode(
+                {**original_params,
+                 **additional_query}, doseq=True)
+            return parsed_url._replace(query=updated_query).geturl()
+        url = update_url(url, {'per_page': 100})
         messages_json = []
         async with client_session.get(url) as response:
             response = response  # type: aiohttp.ClientResponse

--- a/linty_fresh/reporters/github_reporter.py
+++ b/linty_fresh/reporters/github_reporter.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from typing import Any, Dict, List, MutableMapping, Optional, Set, TypeVar
 from urllib.parse import parse_qs, urlencode, urlparse
 
-import aiohttp
+import aiohttp  # noqa
 
 from linty_fresh.problem import Problem, TestProblem
 

--- a/linty_fresh/reporters/github_reporter.py
+++ b/linty_fresh/reporters/github_reporter.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from typing import Any, Dict, List, MutableMapping, Optional, Set, TypeVar
 from urllib.parse import parse_qs, urlencode, urlparse
 
-import aiohttp  # noqa
+import aiohttp
 
 from linty_fresh.problem import Problem, TestProblem
 

--- a/tests/reporters/test_github_reporter.py
+++ b/tests/reporters/test_github_reporter.py
@@ -86,12 +86,12 @@ class GithubReporterTest(unittest.TestCase):
                 'Authorization': 'token MY_TOKEN'
             })
         existing_comments_request = call.get(
-            'https://api.github.com/repos/foo/bar/pulls/1234/comments',
+            'https://api.github.com/repos/foo/bar/pulls/1234/comments?per_page=100',
             headers={
                 'Authorization': 'token MY_TOKEN'
             })
         existing_issues_request = call.get(
-            'https://api.github.com/repos/foo/bar/issues/1234/comments',
+            'https://api.github.com/repos/foo/bar/issues/1234/comments?per_page=100',
             headers={
                 'Authorization': 'token MY_TOKEN'
             })
@@ -271,7 +271,7 @@ class GithubReporterTest(unittest.TestCase):
         fake_client_session = FakeClientSession(url_map={
             ('https://api.github.com/repos/foo/bar/pulls/1234', 'get'):
                 FakeClientResponse(GithubReporterTest.github_patch),
-            ('https://api.github.com/repos/foo/bar/pulls/1234/comments',
+            ('https://api.github.com/repos/foo/bar/pulls/1234/comments?per_page=100',
              'get'): FakeClientResponse(json.dumps([{
                  'id': 1,
                  'path': 'another_file',
@@ -286,7 +286,7 @@ class GithubReporterTest(unittest.TestCase):
              'post'): FakeClientResponse(''),
             ('https://api.github.com/repos/foo/bar/issues/1234/comments',
              'post'): FakeClientResponse(''),
-            ('https://api.github.com/repos/foo/bar/issues/1234/comments',
+            ('https://api.github.com/repos/foo/bar/issues/1234/comments?per_page=100',
              'get'): FakeClientResponse('[]'),
             ('https://api.github.com/repos/foo/bar/pulls/comments/1',
              'delete'): FakeClientResponse('')
@@ -327,7 +327,7 @@ class GithubReporterTest(unittest.TestCase):
     def test_messages_paging(self):
         reporter = GithubReporter('TOKEN', 'foo', 'bar', 12, 'abc123', False)
         client_session = FakeClientSession(url_map={
-            ('https://api.github.com/repos/foo/bar/pulls/12/comments', 'get'):
+            ('https://api.github.com/repos/foo/bar/pulls/12/comments?per_page=100', 'get'):
                 FakeClientResponse(json.dumps([{
                     'id': 1,
                     'path': 'file1',
@@ -338,7 +338,7 @@ class GithubReporterTest(unittest.TestCase):
                     'link': '<https://api.github.com/repos/foo/bar/'
                             'pulls/12/comments?page=1>; rel="next"'
                 }),
-            ('https://api.github.com/repos/foo/bar/pulls/12/comments?page=1',
+            ('https://api.github.com/repos/foo/bar/pulls/12/comments?page=1&per_page=100',
              'get'):
                 FakeClientResponse(json.dumps([{
                     'id': 2,


### PR DESCRIPTION
Set per_page param for getting github comments to the max allowable

**Note:**
- default: 30
- max: 100