### PR TITLE
Revert "Bump python version and aiohttp library (#56)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - "3.6"
+  - "3.5"
 
 install:
   - scripts/setup.sh

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'pycodestyle>=2.0.0, <2.1.0',
     ],
     install_requires=[
-        'aiohttp>=3.6.2, <4.0.0',
+        'aiohttp>=0.19.0, <3.0.0',
         'typing>=3.5.0.1, <4.0.0;python_version<"3.7"',
     ],
     classifiers=[


### PR DESCRIPTION
This reverts commit 9aa2b7621872dcadc80538d56a3a6cef2abdbb55.

When running after this change we see:

```
Traceback (most recent call last):
  File "/private/var/tmp/b/3263360e4c13ed7221fd5574dfffe441/execroot/lyftios/bazel-out/darwin-opt/bin/tools/lintyfresh/lintyfresh.runfiles/lyftios/tools/lintyfresh/linty_fresh_runner.py", line 9, in <module>
    linty_fresh.main.main()
  File "/private/var/tmp/b/3263360e4c13ed7221fd5574dfffe441/execroot/lyftios/bazel-out/darwin-opt/bin/tools/lintyfresh/lintyfresh.runfiles/pip_deps/pypi__linty_fresh/linty_fresh/main.py", line 95, in main
    loop.run_until_complete(run_loop(args))
  File "/Applications/Xcode-12.2.0.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/private/var/tmp/b/3263360e4c13ed7221fd5574dfffe441/execroot/lyftios/bazel-out/darwin-opt/bin/tools/lintyfresh/lintyfresh.runfiles/pip_deps/pypi__linty_fresh/linty_fresh/main.py", line 87, in run_loop
    await asyncio.gather(*awaitable_array)
  File "/private/var/tmp/b/3263360e4c13ed7221fd5574dfffe441/execroot/lyftios/bazel-out/darwin-opt/bin/tools/lintyfresh/lintyfresh.runfiles/pip_deps/pypi__linty_fresh/linty_fresh/reporters/github_reporter.py", line 82, in report
    with aiohttp.ClientSession(headers=headers) as client_session:
  File "/private/var/tmp/b/3263360e4c13ed7221fd5574dfffe441/execroot/lyftios/bazel-out/darwin-opt/bin/tools/lintyfresh/lintyfresh.runfiles/pip_deps/pypi__aiohttp/aiohttp/client.py", line 1070, in __enter__
    raise TypeError("Use async with instead")
TypeError: Use async with instead
```