### PR TITLE
Add async for type error

### DIFF
--- a/linty_fresh/reporters/github_reporter.py
+++ b/linty_fresh/reporters/github_reporter.py
@@ -79,7 +79,7 @@ class GithubReporter(object):
         headers = {
             'Authorization': 'token {}'.format(self.auth_token),
         }
-        with aiohttp.ClientSession(headers=headers) as client_session:
+        async with aiohttp.ClientSession(headers=headers) as client_session:
             (line_map, existing_messages, message_ids) = await asyncio.gather(
                 self.create_line_to_position_map(client_session),
                 self.get_existing_pr_messages(client_session, linter_name),


### PR DESCRIPTION
Hoping this fixes this error:

```
Traceback (most recent call last):
  File "/private/var/tmp/b/3263360e4c13ed7221fd5574dfffe441/execroot/lyftios/bazel-out/darwin-opt/bin/tools/lintyfresh/lintyfresh.runfiles/lyftios/tools/lintyfresh/linty_fresh_runner.py", line 9, in <module>
    linty_fresh.main.main()
  File "/private/var/tmp/b/3263360e4c13ed7221fd5574dfffe441/execroot/lyftios/bazel-out/darwin-opt/bin/tools/lintyfresh/lintyfresh.runfiles/pip_deps/pypi__linty_fresh/linty_fresh/main.py", line 95, in main
    loop.run_until_complete(run_loop(args))
  File "/Applications/Xcode-12.2.0.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/private/var/tmp/b/3263360e4c13ed7221fd5574dfffe441/execroot/lyftios/bazel-out/darwin-opt/bin/tools/lintyfresh/lintyfresh.runfiles/pip_deps/pypi__linty_fresh/linty_fresh/main.py", line 87, in run_loop
    await asyncio.gather(*awaitable_array)
  File "/private/var/tmp/b/3263360e4c13ed7221fd5574dfffe441/execroot/lyftios/bazel-out/darwin-opt/bin/tools/lintyfresh/lintyfresh.runfiles/pip_deps/pypi__linty_fresh/linty_fresh/reporters/github_reporter.py", line 82, in report
    with aiohttp.ClientSession(headers=headers) as client_session:
  File "/private/var/tmp/b/3263360e4c13ed7221fd5574dfffe441/execroot/lyftios/bazel-out/darwin-opt/bin/tools/lintyfresh/lintyfresh.runfiles/pip_deps/pypi__aiohttp/aiohttp/client.py", line 1070, in __enter__
    raise TypeError("Use async with instead")
TypeError: Use async with instead
```