### PR TITLE
Move to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,41 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.3.0
+    hooks:
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: requirements-txt-fixer
+  # - repo: https://github.com/timothycrosley/isort
+  #   rev: 5.6.4
+  #   hooks:
+  #     - id: isort
+  # - repo: https://github.com/ambv/black
+  #   rev: 20.8b1
+  #   hooks:
+  #     - id: black
+  #       language_version: python3
+  # - repo: https://github.com/asottile/pyupgrade
+  #   rev: v2.7.3
+  #   hooks:
+  #     - id: pyupgrade
+  #       args: [--py36-plus]
+  # - repo: https://github.com/pre-commit/pygrep-hooks
+  #   rev: v1.6.0
+  #   hooks:
+  #     - id: python-check-blanket-noqa
+  #     - id: python-check-mock-methods
+  #     - id: python-no-log-warn
+  # - repo: https://github.com/pre-commit/mirrors-mypy
+  #   rev: v0.790
+  #   hooks:
+  #     - id: mypy
+  #       args: [--strict, --ignore-missing-imports]
+  - repo: https://github.com/PyCQA/flake8
+    rev: 3.8.4
+    hooks:
+      - id: flake8
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.7.1.1
+    hooks:
+      - id: shellcheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
     rev: 3.8.4
     hooks:
       - id: flake8
+        args: [--ignore, E501]
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.7.1.1
     hooks:

--- a/linty_fresh/problem.py
+++ b/linty_fresh/problem.py
@@ -12,8 +12,7 @@ class Problem(object):
         return hash((self.path, self.line, self.message))
 
     def __eq__(self, other):
-        return ((self.path, self.line, self.message) ==
-                (other.path, other.line, other.message))
+        return ((self.path, self.line, self.message) == (other.path, other.line, other.message))
 
     def to_json(self):
         return OrderedDict({
@@ -54,11 +53,10 @@ class TestProblem(object):
         return ((self.test_group,
                  self.test_name,
                  self.message,
-                 self.stack_trace) ==
-                (other.test_group,
-                 other.test_name,
-                 other.message,
-                 other.stack_trace))
+                 self.stack_trace) == (other.test_group,
+                                       other.test_name,
+                                       other.message,
+                                       other.stack_trace))
 
     def to_json(self):
         return OrderedDict({

--- a/linty_fresh/reporters/github_reporter.py
+++ b/linty_fresh/reporters/github_reporter.py
@@ -43,10 +43,9 @@ class ExistingGithubMessage(object):
 
     def __eq__(self, other):
         if isinstance(self, other.__class__):
-            return (self.path == other.path and
-                    self.position == other.position and
-                    self.body == other.body)
+            return (self.path == other.path and self.position == other.position and self.body == other.body)
         return False
+
 
 GenericProblem = TypeVar('GenericProblem', Problem, TestProblem)
 
@@ -100,7 +99,7 @@ class GithubReporter(object):
                 if position is None and path in line_map:
                     file_map = line_map[path]
                     closest_line = min(file_map.keys(),
-                                       key=lambda x: abs(x-line_number))
+                                       key=lambda x: abs(x - line_number))
                     position = file_map[closest_line]
                     message_for_line.append('(From line {})'.format(
                         line_number))

--- a/linty_fresh/storage/git_storage_engine.py
+++ b/linty_fresh/storage/git_storage_engine.py
@@ -18,7 +18,7 @@ GIT_SUBPROCESS_KWARGS = {
 
 
 class GitNotesStorageEngine(object):
-    def __init__(self, remote: str=None):
+    def __init__(self, remote: str = None):
         self.remote = remote
 
     async def get_note_ref(self, last_n_revisions) -> None:

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,33 +1,7 @@
-#!/bin/bash -x
+#!/bin/bash
 
-set -e
+set -euo pipefail
+set -x
+
 python setup.py test
-
-# This is a bit of a hack.  Travis tests pushes to branches and pull
-# requests.  Unfortunately, the pull request tests are testing the merge
-# commit between the PR and master.  This is desirable for unit tests,
-# but for lint it's less desirable due to line numbers not matching up.
-if [ -n "${TRAVIS_PULL_REQUEST}" ] && \
-   [ "${TRAVIS_PULL_REQUEST}" != 'false' ]; then
-    git checkout HEAD^2
-fi
-
-COMMIT="$(git rev-parse HEAD)"
-
-set +e
-set -o pipefail
-
-python setup.py flake8 | tee flake8.txt
-LINT_RESULT=$?
-
-if [ -n "${TRAVIS_PULL_REQUEST}" ] && \
-   [ "${TRAVIS_PULL_REQUEST}" != 'false' ] && \
-   [ -n "${TRAVIS_REPO_SLUG}" ] && \
-   [ -n "${GITHUB_AUTH_TOKEN}" ]; then
-    COMMIT="$(git rev-parse HEAD)"
-    PR_URL="https://github.com/${TRAVIS_REPO_SLUG}/pull/${TRAVIS_PULL_REQUEST}"
-    linty_fresh --pr_url "${PR_URL}" --commit "${COMMIT}" \
-                --linter pylint flake8.txt
-fi
-
-exit ${LINT_RESULT}
+pre-commit run -a

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,3 +1,4 @@
 #!/bin/bash -ex
 
+pip install pre-commit
 python setup.py install

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,13 +18,6 @@ classifiers =
 [options]
 packages = find:
 include_package_data = True
-setup_requires =
-    flake8>=2.2.3, <3.0.0
-    flake8-blind-except==0.1.1
-    flake8-debugger>=1.4.0, <4.0.0
-    flake8-import-order>=0.10, <0.19
-    flake8-quotes>=0.8.1, <3.2.0
-    pycodestyle>=2.0.0, <2.1.0
 install_requires =
     aiohttp>=3.6.2, <4.0.0
     typing>=3.5.0.1, <4.0.0;python_version<"3.7"

--- a/tests/linters/test_android.py
+++ b/tests/linters/test_android.py
@@ -56,10 +56,10 @@ class AndroidLintTest(unittest.TestCase):
         result = android.parse(test_string, pass_warnings=False)
         self.assertEqual(2, len(result))
         self.assertIn(Problem('scripts/run_tests.sh',
-                                      15,
-                                      'ScrollView size validation: This LinearLayout '
-                                      'should use '
-                                      '`android:layout_height="wrap_content"`'),
+                              15,
+                              'ScrollView size validation: This LinearLayout '
+                              'should use '
+                              '`android:layout_height="wrap_content"`'),
                       result)
 
         self.assertIn(Problem('scripts/setup.sh',
@@ -74,8 +74,8 @@ class AndroidLintTest(unittest.TestCase):
         result = android.parse(test_string, pass_warnings=True)
         self.assertEqual(1, len(result))
         self.assertIn(Problem('scripts/run_tests.sh',
-                                      15,
-                                      'ScrollView size validation: This LinearLayout '
-                                      'should use '
-                                      '`android:layout_height="wrap_content"`'),
+                              15,
+                              'ScrollView size validation: This LinearLayout '
+                              'should use '
+                              '`android:layout_height="wrap_content"`'),
                       result)

--- a/tests/linters/test_pmd.py
+++ b/tests/linters/test_pmd.py
@@ -3,12 +3,13 @@ import os
 from linty_fresh.linters import pmd
 from linty_fresh.problem import Problem
 
+
 class PmdTest(unittest.TestCase):
     def test_empty_parse(self):
         self.assertEqual(set(), pmd.parse(''))
 
     def test_parse_errors(self):
-            test_string = """\
+        test_string = """\
 <?xml version="1.0" encoding="UTF-8"?>
 <pmd version="5.5.0" timestamp="2016-07-06T11:29:03.360">
     <file name="{0}/DriverRideDrivingToWaypointController.java">
@@ -22,18 +23,18 @@ class PmdTest(unittest.TestCase):
         </violation>
     </file>
 </pmd>
-    """.format(os.path.curdir)
+        """.format(os.path.curdir)
 
-            result = pmd.parse(test_string)
-            self.assertEqual(2, len(result))
-            self.assertIn(Problem('./DriverRideDrivingToWaypointController.java',
-                                  287,
-                                  'UnusedFormalParameter: Avoid unused method' 
-                                  " parameters such as 'ride'."),
-                          result)
+        result = pmd.parse(test_string)
+        self.assertEqual(2, len(result))
+        self.assertIn(Problem('./DriverRideDrivingToWaypointController.java',
+                              287,
+                              'UnusedFormalParameter: Avoid unused method'
+                              " parameters such as 'ride'."),
+                      result)
 
-            self.assertIn(Problem('./AddCouponView.java',
-                                  24,
-                                  'UnusedImports: Avoid unused imports such as'
-                                  " 'me.lyft.android.common.Strings'"),
-                          result)
+        self.assertIn(Problem('./AddCouponView.java',
+                              24,
+                              'UnusedImports: Avoid unused imports such as'
+                              " 'me.lyft.android.common.Strings'"),
+                      result)

--- a/tests/utils/fake_client_session.py
+++ b/tests/utils/fake_client_session.py
@@ -9,6 +9,7 @@ class FakeClientResponse(object):
     def __init__(self, content, headers=None):
         self.headers = headers or {}
         self.content = FakeStreamReader(content)
+
     async def text(self):
         return self.content.content
 
@@ -32,8 +33,8 @@ class FakeClientResponse(object):
 
 class FakeClientSession(object):
     def __init__(self,
-                 headers: Dict[str, str]=None,
-                 url_map: Dict[Tuple[str, str], FakeClientResponse]=None,
+                 headers: Dict[str, str] = None,
+                 url_map: Dict[Tuple[str, str], FakeClientResponse] = None,
                  *args, **kwargs):
         self.headers = headers
         self.url_map = url_map


### PR DESCRIPTION
This removes our usage of setup_requires for development only
dependencies, and manages linters in a way that I think is nicer in
general. This fixes an issue we hit where setup_requires, even though
it's not consumed upstream, broke upstream dependees because of invalid
version locking.