### PR TITLE
Fix aiohttp.ClientSession usage

### DIFF
--- a/linty_fresh/reporters/github_reporter.py
+++ b/linty_fresh/reporters/github_reporter.py
@@ -77,7 +77,7 @@ class GithubReporter:
         headers = {
             'Authorization': f'token {self.auth_token}',
         }
-        with aiohttp.ClientSession(headers=headers) as client_session:
+        async with aiohttp.ClientSession(headers=headers) as client_session:
             (line_map, existing_messages, message_ids) = await asyncio.gather(
                 self.create_line_to_position_map(client_session),
                 self.get_existing_pr_messages(client_session, linter_name),

--- a/tests/utils/fake_client_session.py
+++ b/tests/utils/fake_client_session.py
@@ -50,6 +50,12 @@ class FakeClientSession:
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
 
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
     async def _get_stored_value(self, url, method):
         if (url, method) not in self.url_map:
             raise Exception('Invalid test request: ({}, {})'.format(


### PR DESCRIPTION
`async with` is required. This made the tests failed because our fake
object didn't implement `__aenter__` and `__aexit__` so now it does